### PR TITLE
A boolean parameter is added to make the enum enum or suggested value

### DIFF
--- a/aepp/schema.py
+++ b/aepp/schema.py
@@ -2568,7 +2568,7 @@ class FieldGroupManager:
         return list(result_combi)
 
         
-    def addFieldOperation(self,path:str,dataType:str=None,title:str=None,objectComponents:dict=None,array:bool=False,enumValues:dict=None,**kwargs)->None:
+    def addFieldOperation(self,path:str,dataType:str=None,title:str=None,objectComponents:dict=None,array:bool=False,enumValues:dict=None,enumType:bool=None,**kwargs)->None:
         """
         Return the operation to be used on the field group with the Patch method (patchFieldGroup), based on the element passed in argument.
         Arguments:
@@ -2582,6 +2582,7 @@ class FieldGroupManager:
                 Example : {'field1':'string','field2':'double'}
             array : OPTIONAL : Boolean. If the element to create is an array. False by default.
             enumValues : OPTIONAL : If your field is an enum, provid a dictionary of value and display name, such as : {'value':'display'}
+            enumType: OPTIONAL: If your field is an enum, indicates whether it is an enum (True) or suggested values (False)
         possible kwargs:
             defaultPath : Define which path to take by default for adding new field on tenant. Default "property", possible alternative : "customFields"
         """
@@ -2625,14 +2626,16 @@ class FieldGroupManager:
         operation[0]['value']['title'] = title
         if enumValues is not None and type(enumValues) == dict:
             if array == False:
-                operation[0]['value']['enum'] = [enumValues.keys()]
                 operation[0]['value']['meta:enum'] = enumValues
+                if enumType:
+                    operation[0]['value']['enum'] = list(enumValues.keys())
             else:
-                operation[0]['value']['items']['enum'] = [enumValues.keys()]
                 operation[0]['value']['items']['meta:enum'] = enumValues
+                if enumType:
+                    operation[0]['value']['items']['enum'] = list(enumValues.keys())
         return operation
 
-    def addField(self,path:str,dataType:str=None,title:str=None,objectComponents:dict=None,array:bool=False,enumValues:dict=None,**kwargs)->dict:
+    def addField(self,path:str,dataType:str=None,title:str=None,objectComponents:dict=None,array:bool=False,enumValues:dict=None,enumType:bool=None,**kwargs)->dict:
         """
         Add the field to the existing fieldgroup definition.
         Returns False when the field could not be inserted.
@@ -2646,6 +2649,7 @@ class FieldGroupManager:
                 Example : {'field1:'string','field2':'double'}
             array : OPTIONAL : Boolean. If the element to create is an array. False by default.
             enumValues : OPTIONAL : If your field is an enum, provid a dictionary of value and display name, such as : {'value':'display'}
+            enumType: OPTIONAL: If your field is an enum, indicates whether it is an enum (True) or suggested values (False)
         possible kwargs:
             defaultPath : Define which path to take by default for adding new field on tenant. Default "property", possible alternative : "customFields"
         """
@@ -2684,11 +2688,13 @@ class FieldGroupManager:
                 obj['items'] = self.__transformFieldType__(dataType)
         if enumValues is not None and type(enumValues) == dict:
             if array == False:
-                obj['enum'] = list(enumValues.keys())
                 obj['meta:enum'] = enumValues
+                if enumType:
+                    obj['enum'] = list(enumValues.keys())
             else:
-                obj['items']['enum'] = [enumValues.keys()]
                 obj['items']['meta:enum'] = enumValues
+                if enumType:
+                    obj['items']['enum'] = list(enumValues.keys())
         completePath:list[str] = [kwargs.get('defaultPath','property')] + pathSplit
         customFields,foundFlag = self.__setField__(completePath, self.fieldGroup['definitions'],newField,obj)
         if foundFlag == False:

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -406,6 +406,7 @@ Arguments:
 * array : OPTIONAL : Boolean. If the element to create is an array. False by default.
 * enumValues : OPTIONAL : If your field is an enum, provide a dictionary of value and display name, such as : {'value':'display'}\
 possible kwargs:
+* enumType: OPTIONAL: If your field is an enum, indicates whether it is an enum (True) or suggested values (False)
 * defaultPath : Define which path to take by default for adding new field on tenant. Default "property", possible alternative : "customFields"
 
 Examples : *TBD*
@@ -425,6 +426,7 @@ Arguments:
     Example : {'field1:'string','field2':'double'}
 * array : OPTIONAL : Boolean. If the element to create is an array. False by default.
 * enumValues : OPTIONAL : If your field is an enum, provide a dictionary of value and display name, such as : {'value':'display'}\
+* enumType: OPTIONAL: If your field is an enum, indicates whether it is an enum (True) or suggested values (False)
 possible kwargs:
 * defaultPath : Define which path to take by default for adding new field on tenant. Default "property", possible alternative : "customFields"
 


### PR DESCRIPTION
The changes fix the error when creating enums and let the user decide if they want enums or suggested values

## Description

The methods addField and addFieldOperation in schema are modified with a new parameter enumType and updated code. Also the docs are updated.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

there was a bug and no possibility to choose between suggested values or enums

## How Has This Been Tested?

2 Field groups were created using the code. 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
