### PR TITLE
fix: createRecordDeleteRequest method in hygiene api

### DIFF
--- a/aepp/hygiene.py
+++ b/aepp/hygiene.py
@@ -188,7 +188,7 @@ class Hygiene:
         path = f"/ttl/{ttlId}"
         if self.loggingEnabled:
             self.logger.debug(f"Starting deleteDatasetExpiration, ttlId: {ttlId}")
-        res = self.connector.deleteData(self.endpoint+path)
+        res = self.connector.postData(self.endpoint+path)
         return res
 
     def createRecordDeleteRequest(self,datasetId:str="ALL",name:str=None,identities:list=None,description:str="")->dict:

--- a/aepp/hygiene.py
+++ b/aepp/hygiene.py
@@ -188,7 +188,7 @@ class Hygiene:
         path = f"/ttl/{ttlId}"
         if self.loggingEnabled:
             self.logger.debug(f"Starting deleteDatasetExpiration, ttlId: {ttlId}")
-        res = self.connector.postData(self.endpoint+path)
+        res = self.connector.deleteData(self.endpoint+path)
         return res
 
     def createRecordDeleteRequest(self,datasetId:str="ALL",name:str=None,identities:list=None,description:str="")->dict:
@@ -221,7 +221,7 @@ class Hygiene:
             "description": description,
             "identities":identities
         }
-        res = self.connector.getData(self.endpoint+path,data=data)
+        res = self.connector.postData(self.endpoint+path,data=data)
         return res
     
     def getWorkOrderStatus(self,workorderId:str=None)->dict:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The method did not delte the data but created a get instead of a post request.

https://experienceleague.adobe.com/en/docs/experience-platform/data-lifecycle/api/workorder