### PR TITLE
fix random number generation in schema.py to use exponentiation for c…

### DIFF
--- a/aepp/schema.py
+++ b/aepp/schema.py
@@ -486,7 +486,7 @@ class Schema:
 
         if self.loggingEnabled:
             self.logger.debug(f"Starting getSchemaSample")
-        rand_number = random.randint(1, 10e10)
+        rand_number = random.randint(1, 10**10)
         if schemaId is None:
             raise Exception("Require an ID for the schema")
         if schemaId.startswith("https://"):


### PR DESCRIPTION
Fix TypeError in Schema.getSchemaSample() when generating random number

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

In `aepp/schema.py`, the `getSchemaSample()` method used `random.randint(1, 10e10)` to generate a random number. In Python, `10e10` is a float (scientific notation). `random.randint()` requires integer arguments, which caused:

```
TypeError: 'float' object cannot be interpreted as an integer
```

The fix replaces `10e10` with `10**10`, which is the integer 10,000,000,000 and preserves the intended range.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A – direct bug fix for runtime TypeError.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Calling `Schema.getSchemaSample(schemaId)` raised a `TypeError` and prevented retrieving schema samples. This change restores correct behavior with a one-line fix and no API or behavioral change beyond fixing the error.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified the fix in a Python environment (Python 3.12) by calling `mySchema.getSchemaSample(schemaId)` after the change; the call completes without error.
- Confirmed `10**10` evaluates to the integer `10000000000` and that `random.randint(1, 10**10)` returns values in the expected range.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
